### PR TITLE
In AA Ecosystem spec 1.1.3, KeyMaterial curve is renamed to Curve25519

### DIFF
--- a/src/main/java/io/yaazhi/forwardsecrecy/dto/SerializedKeyPair.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/dto/SerializedKeyPair.java
@@ -14,8 +14,8 @@ public class SerializedKeyPair{
     @NonNull
     final private String privateKey;
     @NonNull
-    @JsonProperty("KeyMaterials")
-    KeyMaterial keyMaterials;
+    @JsonProperty("KeyMaterial")
+    KeyMaterial keyMaterial;
     @Nullable
     ErrorInfo errorInfo;
 }

--- a/src/main/java/io/yaazhi/forwardsecrecy/service/ECCService.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/service/ECCService.java
@@ -34,7 +34,7 @@ import lombok.extern.java.Log;
 @Log
 @Service
 public class ECCService {
-    @Value("${forwardsecrecy.ecc.curve:curve25519}")
+    @Value("${forwardsecrecy.ecc.curve:Curve25519}")
     String curve;
     @Value("${forwardsecrecy.ecc.algorithm:EC}")
     String algorithm;

--- a/src/test/java/io/yaazhi/forwardsecrecy/controller/ECCControllerTest.java
+++ b/src/test/java/io/yaazhi/forwardsecrecy/controller/ECCControllerTest.java
@@ -57,7 +57,7 @@ class ECCControllerTest {
         encryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(remoteNonce));
         encryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(ourNonce));
         encryptCipherParam.setOurPrivateKey(ourSerializedKeyPair.getPrivateKey());
-        encryptCipherParam.setRemoteKeyMaterial(remoteSerializedKeyPair.getKeyMaterials());
+        encryptCipherParam.setRemoteKeyMaterial(remoteSerializedKeyPair.getKeyMaterial());
         CipherResponse encryptedCipherResponse = eccController.encrypt(encryptCipherParam);
         
         //Remote Decryption
@@ -67,7 +67,7 @@ class ECCControllerTest {
         decryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(ourNonce));
         decryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(remoteNonce));
         decryptCipherParam.setOurPrivateKey(remoteSerializedKeyPair.getPrivateKey());
-        decryptCipherParam.setRemoteKeyMaterial(ourSerializedKeyPair.getKeyMaterials());
+        decryptCipherParam.setRemoteKeyMaterial(ourSerializedKeyPair.getKeyMaterial());
         
         CipherResponse decryptedCipherResponse = eccController.decrypt(decryptCipherParam);
         //System.out.println(decryptedCipherResponse.getBase64Data());
@@ -79,12 +79,12 @@ class ECCControllerTest {
     public void testValidateTheSecretKeyGeneratedOnClientAndServerIsSimilar()  {
         //Generate server key pair
         final SerializedKeyPair serverKeyPair = eccController.generateKey();
-        String serverPublicKey = serverKeyPair.getKeyMaterials().getDhPublicKey().getKeyValue();
+        String serverPublicKey = serverKeyPair.getKeyMaterial().getDhPublicKey().getKeyValue();
         String serverPrivateKey = serverKeyPair.getPrivateKey();
 
         //Generate remote key pair
         final SerializedKeyPair clientKeyPair = eccController.generateKey();
-        String clientPublicKey = clientKeyPair.getKeyMaterials().getDhPublicKey().getKeyValue();
+        String clientPublicKey = clientKeyPair.getKeyMaterial().getDhPublicKey().getKeyValue();
         String clientPrivateKey = clientKeyPair.getPrivateKey();
 
         //Happening on Server


### PR DESCRIPTION
In AA Ecosystem spec 1.1.3, KeyMaterial curve is renamed with a capital 'C' from curve25519 to Curve25519.

After this change gradle build is successful with unit test cases.

