### PR TITLE
Encrypt API request body field "base64Data" changed to "data"

### DIFF
--- a/src/main/java/io/yaazhi/forwardsecrecy/controller/ECCController.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/controller/ECCController.java
@@ -12,7 +12,8 @@ import javax.crypto.NoSuchPaddingException;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import io.yaazhi.forwardsecrecy.dto.CipherParameter;
+import io.yaazhi.forwardsecrecy.dto.EncryptCipherParameter;
+import io.yaazhi.forwardsecrecy.dto.DecryptCipherParameter;
 import io.yaazhi.forwardsecrecy.dto.CipherResponse;
 import io.yaazhi.forwardsecrecy.dto.ErrorInfo;
 import io.yaazhi.forwardsecrecy.dto.KeyMaterial;
@@ -108,16 +109,16 @@ public class ECCController {
     @PostMapping(value = "/encrypt", consumes = "application/json", produces = "application/json")
     @ApiResponses({ @ApiResponse(code = 200, message = " successfully encrypted the data"),
 			@ApiResponse(code = 500, message = " error occured while encrypting the given data") })
-    public CipherResponse encrypt(@RequestBody final CipherParameter cipherParam) {
+    public CipherResponse encrypt(@RequestBody final EncryptCipherParameter encryptCipherParam) {
         try {
             log.info("Encrypt complete data");
             log.log(Level.FINE, "Get PrivateKey");
-            final Key ourPrivateKey = eccService.getPEMDecodedStream(cipherParam.getOurPrivateKey());
+            final Key ourPrivateKey = eccService.getPEMDecodedStream(encryptCipherParam.getOurPrivateKey());
             log.log(Level.FINE, "Get PublicKey");
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Quoted "Z" to indicate UTC, no 
             Date expiryDate;
             try {
-                expiryDate = df.parse(cipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
+                expiryDate = df.parse(encryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
             }
             catch(ParseException ex){
                 throw new InvalidKeyException("Unable to parse date");
@@ -126,9 +127,9 @@ public class ECCController {
             if (!expiryDate.after(new Date())){
                 throw new InvalidKeyException("Expired Key");
             }
-            final Key ourPublicKey = eccService.getPEMDecodedStream(cipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue());
+            final Key ourPublicKey = eccService.getPEMDecodedStream(encryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue());
             log.log(Level.FINE, "Initiate Encryption");
-            String result= cipherService.encrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, cipherParam.getBase64YourNonce(), cipherParam.getBase64RemoteNonce(), cipherParam.getBase64Data());
+            String result= cipherService.encrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, encryptCipherParam.getBase64YourNonce(), encryptCipherParam.getBase64RemoteNonce(), encryptCipherParam.getData());
             log.log(Level.FINE, "Completed Encryption");
             return new CipherResponse(result, null);
 
@@ -149,16 +150,16 @@ public class ECCController {
     @PostMapping(value = "/decrypt", consumes = "application/json", produces = "application/json")
     @ApiResponses({ @ApiResponse(code = 200, message = " successfully encrypted the data"),
 			@ApiResponse(code = 500, message = " error occured while encrypting the given data") })
-    public CipherResponse decrypt(@RequestBody final CipherParameter cipherParam) {
+    public CipherResponse decrypt(@RequestBody final DecryptCipherParameter decryptCipherParam) {
         try {
             log.info("Decrypt complete data");
             log.log(Level.FINE, "Get PrivateKey");
-            final Key ourPrivateKey = eccService.getPEMDecodedStream(cipherParam.getOurPrivateKey());
+            final Key ourPrivateKey = eccService.getPEMDecodedStream(decryptCipherParam.getOurPrivateKey());
             log.log(Level.FINE, "Get PublicKey");
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Quoted "Z" to indicate UTC, no 
             Date expiryDate;
             try {
-                expiryDate = df.parse(cipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
+                expiryDate = df.parse(decryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
             }
             catch(ParseException ex){
                 throw new InvalidKeyException("Unable to parse date");
@@ -167,9 +168,9 @@ public class ECCController {
             if (!expiryDate.after(new Date())){
                 throw new InvalidKeyException("Expired Key");
             }
-            final Key ourPublicKey = eccService.getPEMDecodedStream(cipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue());
+            final Key ourPublicKey = eccService.getPEMDecodedStream(decryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue());
             log.log(Level.FINE, "Initiate Decryption");
-            String result= cipherService.decrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, cipherParam.getBase64YourNonce(), cipherParam.getBase64RemoteNonce(), cipherParam.getBase64Data());
+            String result= cipherService.decrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, decryptCipherParam.getBase64YourNonce(), decryptCipherParam.getBase64RemoteNonce(), decryptCipherParam.getBase64Data());
             log.log(Level.FINE, "Completed Decryption");
             return new CipherResponse(result, null);
 

--- a/src/main/java/io/yaazhi/forwardsecrecy/dto/DecryptCipherParameter.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/dto/DecryptCipherParameter.java
@@ -1,0 +1,27 @@
+package io.yaazhi.forwardsecrecy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.ToString;
+
+@ToString(includeFieldNames=true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DecryptCipherParameter{
+
+    @NonNull
+    KeyMaterial remoteKeyMaterial;
+    @NonNull
+    String ourPrivateKey;
+    @NonNull
+    String base64YourNonce;
+    @NonNull
+    String base64RemoteNonce;
+    @NonNull
+    String base64Data;
+   
+}
+

--- a/src/main/java/io/yaazhi/forwardsecrecy/dto/EncryptCipherParameter.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/dto/EncryptCipherParameter.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class CipherParameter{
+public class EncryptCipherParameter{
 
     @NonNull
     KeyMaterial remoteKeyMaterial;
@@ -21,7 +21,7 @@ public class CipherParameter{
     @NonNull
     String base64RemoteNonce;
     @NonNull
-    String base64Data;
+    String data;
    
 }
 

--- a/src/test/java/io/yaazhi/forwardsecrecy/controller/ECCControllerTest.java
+++ b/src/test/java/io/yaazhi/forwardsecrecy/controller/ECCControllerTest.java
@@ -52,8 +52,8 @@ class ECCControllerTest {
         //Your Encryption
         sr.nextBytes(ourNonce);
         sr.nextBytes(remoteNonce);
-        CipherParameter encryptCipherParam = new CipherParameter();
-        encryptCipherParam.setBase64Data(base64Data);
+        EncryptCipherParameter encryptCipherParam = new EncryptCipherParameter();
+        encryptCipherParam.setData(base64Data);
         encryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(remoteNonce));
         encryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(ourNonce));
         encryptCipherParam.setOurPrivateKey(ourSerializedKeyPair.getPrivateKey());
@@ -62,7 +62,7 @@ class ECCControllerTest {
         
         //Remote Decryption
         
-        CipherParameter decryptCipherParam = new CipherParameter();
+        DecryptCipherParameter decryptCipherParam = new DecryptCipherParameter();
         decryptCipherParam.setBase64Data(encryptedCipherResponse.getBase64Data());
         decryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(ourNonce));
         decryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(remoteNonce));


### PR DESCRIPTION
This is to emphasize that plain data to be passed and not base64 encoded, refers issue gsasikumar/forwardsecrecy#5 discrepancy item 3