### PR TITLE
create x25519 service mirroring the ecc service

### DIFF
--- a/src/main/java/io/yaazhi/forwardsecrecy/controller/X25519Controller.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/controller/X25519Controller.java
@@ -1,0 +1,172 @@
+package io.yaazhi.forwardsecrecy.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.yaazhi.forwardsecrecy.dto.*;
+import io.yaazhi.forwardsecrecy.service.CipherService;
+import io.yaazhi.forwardsecrecy.service.X25519Service;
+import io.yaazhi.forwardsecrecy.service.XCipherService;
+import io.yaazhi.forwardsecrecy.service.XExchangeService;
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.IOException;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Level;
+
+
+@Log
+@RestController
+@RequestMapping("/x25519/v1")
+public class X25519Controller {
+
+    @Autowired
+    private X25519Service x25519Service;
+    @Autowired
+    private XExchangeService xExchangeService;
+    @Autowired
+    private XCipherService cipherService;
+
+    @ApiOperation(value = "Generate a new ecc key pair")
+    @GetMapping(value="/generateKey", produces = "application/json")
+    @ApiResponses({ @ApiResponse(code = 200, message = " successfully created"),
+			@ApiResponse(code = 400, message = " Request body passed  is null or invalid"),
+			@ApiResponse(code = 500, message = " Error occured") })
+    public SerializedKeyPair generateKey() {
+        try {
+            log.info("Generate Key");
+            return x25519Service.getKeyPair();
+        }
+        catch( NoSuchProviderException | NoSuchAlgorithmException | InvalidAlgorithmParameterException | IOException ex){
+            log.log(Level.SEVERE, "Unable to generateKey");
+            final SerializedKeyPair errorKeyPair = new SerializedKeyPair("", new KeyMaterial());
+            final ErrorInfo error = new ErrorInfo();
+            error.setErrorCode(ex.getClass().getName());
+            error.setErrorMessage(ex.getMessage());
+            errorKeyPair.setErrorInfo(error);
+            return errorKeyPair;
+        }
+
+    }
+
+    @ApiOperation(value = "Generate the shared key for the given remote public key (other party in X509encoded Spec) and our private key (our private key encoded in PKCS#8 format) ")
+    @PostMapping(value = "/getSharedKey", consumes = "application/json", produces = "application/json")
+    @ApiResponses({ @ApiResponse(code = 200, message = " successfully derived the key"),
+            @ApiResponse(code = 500, message = " error occured while deriving secret key") })
+    public SerializedSecretKey getSharedKey(@RequestBody final SecretKeySpec spec) {
+        try {
+            log.info("Generate Shared Secret");
+            log.log(Level.FINE, "Get PrivateKey");
+            final Key ourPrivateKey = x25519Service.getPEMDecodedStream(spec.getOurPrivateKey(), true);
+            log.log(Level.FINE, "Get PublicKey");
+            final Key ourPublicKey = x25519Service.getPEMDecodedStream(spec.getRemotePublicKey(), false);
+            log.log(Level.FINE, "Got the key decoded. Lets generate secret key");
+            final String secretKey = xExchangeService.getSharedSecret((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey);
+            return new SerializedSecretKey(secretKey);
+        } catch (NoSuchProviderException | NoSuchAlgorithmException | InvalidKeyException | IOException
+                | InvalidKeySpecException ex) {
+            log.log(Level.SEVERE, "Error when deriving secret key");
+            final SerializedSecretKey errorKeyPair = new SerializedSecretKey("");
+            final ErrorInfo error = new ErrorInfo();
+            error.setErrorCode(ex.getClass().getName());
+            error.setErrorMessage(ex.getMessage());
+            errorKeyPair.setErrorInfo(error);
+            return errorKeyPair;
+        }
+
+    }
+
+    @ApiOperation(value = "Encrypt the data for the given key material (other party in X509encoded Spec) and our private key (our private key encoded in PKCS#8 format) , remote nonce (base64) and local nonce (base64). Send the input data as a string. Encryption assumes the given data is a string")
+    @PostMapping(value = "/encrypt", consumes = "application/json", produces = "application/json")
+    @ApiResponses({ @ApiResponse(code = 200, message = " successfully encrypted the data"),
+			@ApiResponse(code = 500, message = " error occured while encrypting the given data") })
+    public CipherResponse encrypt(@RequestBody final EncryptCipherParameter encryptCipherParam) {
+        try {
+            log.info("Encrypt complete data");
+            log.log(Level.FINE, "Get PrivateKey");
+            final Key ourPrivateKey = x25519Service.getPEMDecodedStream(encryptCipherParam.getOurPrivateKey(), true);
+            log.log(Level.FINE, "Get PublicKey");
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Quoted "Z" to indicate UTC, no 
+            Date expiryDate;
+            try {
+                expiryDate = df.parse(encryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
+            }
+            catch(ParseException ex){
+                throw new InvalidKeyException("Unable to parse date");
+            }
+            
+            if (!expiryDate.after(new Date())){
+                throw new InvalidKeyException("Expired Key");
+            }
+            final Key ourPublicKey = x25519Service.getPEMDecodedStream(encryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue(), false);
+            log.log(Level.FINE, "Initiate Encryption");
+            String result= cipherService.encrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, encryptCipherParam.getBase64YourNonce(), encryptCipherParam.getBase64RemoteNonce(), encryptCipherParam.getData());
+            log.log(Level.FINE, "Completed Encryption");
+            return new CipherResponse(result, null);
+
+        } catch (NoSuchProviderException | NoSuchAlgorithmException | InvalidKeyException
+                | InvalidKeySpecException | NoSuchPaddingException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException
+                | IOException ex) {
+
+            log.log(Level.SEVERE, "Error during encryption");
+            final ErrorInfo error = new ErrorInfo();
+            error.setErrorCode(ex.getClass().getName());
+            error.setErrorMessage(ex.getMessage());
+            return new CipherResponse("", error);
+        }
+        
+    }
+    
+    
+    @ApiOperation(value = "Decrypt the data for the given remote public key (other party in X509encoded Spec) and our private key (our private key encoded in PKCS#8 format) , remote nonce (base64) and local nonce (base64). The result is base64 encoded")
+    @PostMapping(value = "/decrypt", consumes = "application/json", produces = "application/json")
+    @ApiResponses({ @ApiResponse(code = 200, message = " successfully encrypted the data"),
+			@ApiResponse(code = 500, message = " error occured while encrypting the given data") })
+    public CipherResponse decrypt(@RequestBody final DecryptCipherParameter decryptCipherParam) {
+        try {
+            log.info("Decrypt complete data");
+            log.log(Level.FINE, "Get PrivateKey");
+            final Key ourPrivateKey = x25519Service.getPEMDecodedStream(decryptCipherParam.getOurPrivateKey(), true);
+            log.log(Level.FINE, "Get PublicKey");
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Quoted "Z" to indicate UTC, no 
+            Date expiryDate;
+            try {
+                expiryDate = df.parse(decryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getExpiry());
+            }
+            catch(ParseException ex){
+                throw new InvalidKeyException("Unable to parse date");
+            }
+            
+            if (!expiryDate.after(new Date())){
+                throw new InvalidKeyException("Expired Key");
+            }
+            final Key ourPublicKey = x25519Service.getPEMDecodedStream(decryptCipherParam.getRemoteKeyMaterial().getDhPublicKey().getKeyValue(), false);
+            log.log(Level.FINE, "Initiate Decryption");
+            String result= cipherService.decrypt((PrivateKey) ourPrivateKey, (PublicKey) ourPublicKey, decryptCipherParam.getBase64YourNonce(), decryptCipherParam.getBase64RemoteNonce(), decryptCipherParam.getBase64Data());
+            log.log(Level.FINE, "Completed Decryption");
+            return new CipherResponse(result, null);
+
+        } catch (NoSuchProviderException | NoSuchAlgorithmException | InvalidKeyException
+                | InvalidKeySpecException | NoSuchPaddingException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException
+                | IOException ex) {
+
+            log.log(Level.SEVERE, "Error during decryption");
+            final ErrorInfo error = new ErrorInfo();
+            error.setErrorCode(ex.getClass().getName());
+            error.setErrorMessage(ex.getMessage());
+            return new CipherResponse("", error);
+        }
+        
+    }
+    
+}

--- a/src/main/java/io/yaazhi/forwardsecrecy/service/X25519Service.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/service/X25519Service.java
@@ -1,0 +1,88 @@
+package io.yaazhi.forwardsecrecy.service;
+
+import io.yaazhi.forwardsecrecy.dto.DHPublicKey;
+import io.yaazhi.forwardsecrecy.dto.KeyMaterial;
+import io.yaazhi.forwardsecrecy.dto.SerializedKeyPair;
+import lombok.extern.java.Log;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.security.*;
+import java.security.spec.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.logging.Level;
+
+@Log
+@Service
+public class X25519Service {
+    @Value("${forwardsecrecy.ecc.algorithm:X25519}")
+    String algorithm;
+    @Value("${forwardsecrecy.ecc.provider:BC}")
+    String provider;
+    @Value("${forwardsecrecy.ecc.keyExpiryDays:30}")
+    int keyExpiry;
+    private SecureRandom random = new SecureRandom();
+
+
+    private KeyPair generateKey()
+            throws NoSuchProviderException, NoSuchAlgorithmException {
+        KeyPairGenerator kpg;
+        kpg = KeyPairGenerator.getInstance(algorithm, provider);
+        return kpg.genKeyPair();
+    }
+
+    public SerializedKeyPair getKeyPair()
+            throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, IOException {
+
+        final KeyPair kp = this.generateKey();
+        final String privateKey = this.getPEMEncodedStream(kp.getPrivate(),true);
+        final String publicKey = this.getPEMEncodedStream(kp.getPublic(), false);
+        Date date = new Date();
+        Calendar cl = Calendar. getInstance();
+        cl.setTime(date);
+        cl.add(Calendar.HOUR, keyExpiry);
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // Quoted "Z" to indicate UTC, no timezone offset
+        df.setTimeZone(tz);
+        String expiryAsISO = df.format(cl.getTime());
+        final DHPublicKey dhPublicKey = new DHPublicKey(expiryAsISO,"",publicKey);
+        final KeyMaterial keyMaterial = new KeyMaterial("X25519","","",dhPublicKey);
+        final SerializedKeyPair serializedKeyPair = new SerializedKeyPair(privateKey, keyMaterial);
+        return serializedKeyPair;
+    }
+
+    public String getPEMEncodedStream(Key key, boolean privateKey) throws IOException {
+
+        String keyDescription = privateKey ? "PRIVATE KEY" : "PUBLIC KEY";
+        StringWriter writer = new StringWriter();
+        PemObject pemObject = new PemObject(keyDescription, key.getEncoded());
+        PemWriter pemWriter = new PemWriter(writer);
+        pemWriter.writeObject(pemObject);
+        pemWriter.flush();
+        pemWriter.close();
+        return writer.toString();
+    }
+
+    public Key getPEMDecodedStream(final String pemEncodedKey, boolean privateKey)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException, IOException {
+        StringReader reader = new StringReader(pemEncodedKey);
+        PemReader pemReader = new PemReader(reader);
+        if(privateKey) {
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(pemReader.readPemObject().getContent());
+            return KeyFactory.getInstance(algorithm, provider).generatePrivate(spec);
+        }
+        else {
+            KeySpec keySpec = new X509EncodedKeySpec(pemReader.readPemObject().getContent());
+            return KeyFactory.getInstance(algorithm, provider).generatePublic(keySpec);
+        }
+    }
+
+}

--- a/src/main/java/io/yaazhi/forwardsecrecy/service/XCipherService.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/service/XCipherService.java
@@ -1,0 +1,105 @@
+package io.yaazhi.forwardsecrecy.service;
+
+import lombok.extern.java.Log;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.*;
+import java.util.Base64;
+
+@Log
+@Service
+public class XCipherService {
+
+    final String algorithm = "ECDH";
+
+    @Value("${forwardsecrecy.cipher.provider:BC}")
+    String provider;
+    @Autowired
+    XExchangeService dheService;
+    // 16 bytes is the size of the gcmtag
+    final int gcmTagLength = 16;
+    // Length of the IV
+    final int ivLength = 12;
+    // out of 32 byte salts the starting point for IV is 21. (32 - 21 = 12) with 0
+    // index its 20
+    final int saltIVOffset = 20;
+
+    public String encrypt(PrivateKey ourPrivatekey, PublicKey remotePublicKey, String base64YourNonce,
+            String base64RemoteNonce, String data)
+            throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException,
+            InvalidAlgorithmParameterException, IllegalBlockSizeException, BadPaddingException {
+        log.info("Attempt to encrypt");
+        //derive the secret key
+        String sharedSecret = dheService.getSharedSecret(ourPrivatekey, remotePublicKey);
+        //Xor the nonce 
+        byte[] xoredNonce = xor(Base64.getDecoder().decode(base64YourNonce), Base64.getDecoder().decode(base64RemoteNonce));
+        //create a session key with the derived secret
+        String key = getSessionKey(Base64.getDecoder().decode(sharedSecret), xoredNonce);
+        // Crease the cipher instance with the neessary encryption algorithm
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", provider);
+        //Create the spec with the given session key
+        SecretKeySpec keySpec = new SecretKeySpec(Base64.getDecoder().decode(key), "AES");
+        byte[] iv = new byte[12];
+        //Copy only the last 12 bytes
+        System.arraycopy(xoredNonce, saltIVOffset, iv, 0, ivLength);
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(gcmTagLength * 8, iv);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
+        byte[] cipherData = cipher.doFinal(data.getBytes());
+
+        return Base64.getEncoder().encodeToString(cipherData);
+    }
+
+    public String decrypt(PrivateKey ourPrivatekey, PublicKey remotePublicKey, String base64YourNonce,
+            String base64RemoteNonce, String base64EncodedData)
+            throws InvalidKeyException, NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException,
+            InvalidAlgorithmParameterException, IllegalBlockSizeException, BadPaddingException {
+
+        log.info("Attempt to decrypt");
+        String sharedSecret = dheService.getSharedSecret(ourPrivatekey, remotePublicKey);
+        byte[] xoredNonce = xor(Base64.getDecoder().decode(base64YourNonce), Base64.getDecoder().decode(base64RemoteNonce));
+        String key = getSessionKey(Base64.getDecoder().decode(sharedSecret), xoredNonce);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", provider);
+        SecretKeySpec keySpec = new SecretKeySpec(Base64.getDecoder().decode(key), "AES");
+        byte[] iv = new byte[12];
+        System.arraycopy(xoredNonce, saltIVOffset, iv, 0, ivLength);
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(gcmTagLength * 8, iv);
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
+        byte[] cipherData = cipher.doFinal(Base64.getDecoder().decode(base64EncodedData));
+
+        return Base64.getEncoder().encodeToString(cipherData);
+    }
+
+    public String getSessionKey(byte[] sharedSecret, byte[] xoredNonce){
+        
+        byte[] salt = new byte[20];
+        System.arraycopy(xoredNonce, 0, salt, 0, 20);
+        HKDFParameters hkdf = new HKDFParameters(sharedSecret, salt, null);
+        HKDFBytesGenerator generator = new HKDFBytesGenerator(new SHA256Digest());
+        generator.init(hkdf);
+        byte[] result = new byte[32];
+        generator.generateBytes(result, 0, 32);
+        return Base64.getEncoder().encodeToString(result);
+    }
+
+    private byte[] xor(byte[] a, byte[] key) {
+        byte[] out = new byte[a.length];
+        for (int i = 0; i < a.length; i++) {
+            out[i] = (byte) (a[i] ^ key[i%key.length]);
+        }
+        return out;
+    }
+    
+  
+
+}

--- a/src/main/java/io/yaazhi/forwardsecrecy/service/XCipherService.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/service/XCipherService.java
@@ -50,7 +50,7 @@ public class XCipherService {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", provider);
         //Create the spec with the given session key
         SecretKeySpec keySpec = new SecretKeySpec(Base64.getDecoder().decode(key), "AES");
-        byte[] iv = new byte[12];
+        byte[] iv = new byte[ivLength];
         //Copy only the last 12 bytes
         System.arraycopy(xoredNonce, saltIVOffset, iv, 0, ivLength);
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(gcmTagLength * 8, iv);
@@ -71,7 +71,7 @@ public class XCipherService {
         String key = getSessionKey(Base64.getDecoder().decode(sharedSecret), xoredNonce);
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", provider);
         SecretKeySpec keySpec = new SecretKeySpec(Base64.getDecoder().decode(key), "AES");
-        byte[] iv = new byte[12];
+        byte[] iv = new byte[ivLength];
         System.arraycopy(xoredNonce, saltIVOffset, iv, 0, ivLength);
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(gcmTagLength * 8, iv);
         cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);

--- a/src/main/java/io/yaazhi/forwardsecrecy/service/XExchangeService.java
+++ b/src/main/java/io/yaazhi/forwardsecrecy/service/XExchangeService.java
@@ -1,0 +1,31 @@
+package io.yaazhi.forwardsecrecy.service;
+
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.KeyAgreement;
+import java.security.*;
+import java.util.Base64;
+import java.util.logging.Level;
+
+@Log
+@Service
+public class XExchangeService {
+    
+    final String algorithm = "X25519";
+    
+    @Value("${forwardsecrecy.dhe.provider:BC}")
+    String provider;    
+        
+
+        public String getSharedSecret(PrivateKey ourPrivatekey, PublicKey remotePublicKey) throws NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException {
+            KeyAgreement ecdhKeyAgreement = KeyAgreement.getInstance(algorithm, provider);
+            ecdhKeyAgreement.init(ourPrivatekey);
+            ecdhKeyAgreement.doPhase(remotePublicKey,true);
+            final byte[] secretKey = ecdhKeyAgreement.generateSecret();
+            log.log(Level.FINE, "Created the secret key");
+            return Base64.getEncoder().encodeToString(secretKey);
+        }
+
+}

--- a/src/test/java/io/yaazhi/forwardsecrecy/controller/X25519ControllerTest.java
+++ b/src/test/java/io/yaazhi/forwardsecrecy/controller/X25519ControllerTest.java
@@ -1,0 +1,102 @@
+package io.yaazhi.forwardsecrecy.controller;
+
+import io.yaazhi.forwardsecrecy.dto.*;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+class X25519ControllerTest {
+
+    @Autowired
+    X25519Controller x25519Controller;
+
+    @BeforeAll
+	public static void beforeClass() {
+		Security.addProvider(new BouncyCastleProvider()); 
+    }
+
+    @Test
+    public void testFullFunction() {
+        //Generate your key pair
+        SerializedKeyPair ourSerializedKeyPair = x25519Controller.generateKey();
+        //No error
+        assertNull(ourSerializedKeyPair.getErrorInfo());
+        assertNotNull(ourSerializedKeyPair.getPrivateKey());
+
+        //Generate remote key pair
+        SerializedKeyPair remoteSerializedKeyPair = x25519Controller.generateKey();
+        //No error
+        assertNull(remoteSerializedKeyPair.getErrorInfo());
+        assertNotNull(remoteSerializedKeyPair.getPrivateKey());
+
+
+        //   String base64Data = "TGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4gTGV0IHVzIHRlc3QgdG8gZW5zdXJlIHdlIGFyZSBhbGwgZG9pbmcgYSBnb29kIGpvYi4gSG9wZSBpdHMgYWxsIHRydWUgdGhhdCB3ZSBhcmUgZG9pbmcgZ29vZC4g";
+        String base64Data = "Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. Let us test to ensure we are all doing a good job. Hope its all true that we are doing good. ";
+        SecureRandom sr = new SecureRandom();
+        byte ourNonce[] = new byte[32];
+        byte remoteNonce[] = new byte[32];
+
+        //Your Encryption
+        sr.nextBytes(ourNonce);
+        sr.nextBytes(remoteNonce);
+        EncryptCipherParameter encryptCipherParam = new EncryptCipherParameter();
+        encryptCipherParam.setData(base64Data);
+        encryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(remoteNonce));
+        encryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(ourNonce));
+        encryptCipherParam.setOurPrivateKey(ourSerializedKeyPair.getPrivateKey());
+        encryptCipherParam.setRemoteKeyMaterial(remoteSerializedKeyPair.getKeyMaterial());
+        CipherResponse encryptedCipherResponse = x25519Controller.encrypt(encryptCipherParam);
+
+        //Remote Decryption
+
+        DecryptCipherParameter decryptCipherParam = new DecryptCipherParameter();
+        decryptCipherParam.setBase64Data(encryptedCipherResponse.getBase64Data());
+        decryptCipherParam.setBase64RemoteNonce(Base64.getEncoder().encodeToString(ourNonce));
+        decryptCipherParam.setBase64YourNonce(Base64.getEncoder().encodeToString(remoteNonce));
+        decryptCipherParam.setOurPrivateKey(remoteSerializedKeyPair.getPrivateKey());
+        decryptCipherParam.setRemoteKeyMaterial(ourSerializedKeyPair.getKeyMaterial());
+
+        CipherResponse decryptedCipherResponse = x25519Controller.decrypt(decryptCipherParam);
+        //System.out.println(decryptedCipherResponse.getBase64Data());
+        assertEquals(base64Data, new String(Base64.getDecoder().decode(decryptedCipherResponse.getBase64Data())), "Encrypted and Decrypted Successfully");
+
+    }
+
+    @Test
+    public void testValidateTheSecretKeyGeneratedOnClientAndServerIsSimilar()  {
+        //Generate server key pair
+        final SerializedKeyPair serverKeyPair = x25519Controller.generateKey();
+        String serverPublicKey = serverKeyPair.getKeyMaterial().getDhPublicKey().getKeyValue();
+        String serverPrivateKey = serverKeyPair.getPrivateKey();
+
+        //Generate remote key pair
+        final SerializedKeyPair clientKeyPair = x25519Controller.generateKey();
+        String clientPublicKey = clientKeyPair.getKeyMaterial().getDhPublicKey().getKeyValue();
+        String clientPrivateKey = clientKeyPair.getPrivateKey();
+
+        //Happening on Server
+        SecretKeySpec spec = new SecretKeySpec(clientPublicKey, serverPrivateKey);
+        SerializedSecretKey serverSideKey = x25519Controller.getSharedKey(spec);
+        System.out.println("The key that is generated on server side is ["+serverSideKey.getKey());
+
+        //Happening on Client
+        SecretKeySpec mobileSpec = new SecretKeySpec(serverPublicKey, clientPrivateKey);
+        SerializedSecretKey clientSideKey = x25519Controller.getSharedKey(mobileSpec);
+        System.out.println("The key that is generated on client side is ["+clientSideKey.getKey());
+
+        Assertions.assertEquals(serverSideKey.getKey(),clientSideKey.getKey());
+    }
+
+
+}


### PR DESCRIPTION
Created an x25519 service which is an almost exact copy of the ECC service with the following differences:

1. X25519 algorithm is used to generate keys  and secret keys
2. For PEM encoding and decoding we now use BouncyCastle methods instead of constructing the strings ourselves
3. The ECC tests have been modified to use x25519 style keys.

With this implemenation we have been able to perform the Diffie Helman Key Exchange with our service written in Python (uses OpenSSL under the hood). Further, we have been able to decrypt data in Python that is encrypted by the Java service.

Without this change we are not able to load, using OpenSSL, the public key that is generated by the EC service. This is because that's a generic EC key and stores all the Curve25519 information within it.